### PR TITLE
Dockerfile improvements

### DIFF
--- a/php/7.0/Dockerfile
+++ b/php/7.0/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:7.0-fpm
+ARG PHP_VERSION=7.0
+FROM php:$PHP_VERSION-fpm
 
 ARG RUNTIME_PACKAGE_DEPS="ssmtp libfreetype6 libjpeg62-turbo unzip git mysql-client sudo rsync liblz4-tool"
 ARG BUILD_PACKAGE_DEPS="libcurl4-openssl-dev libjpeg-dev libpng-dev libxml2-dev"

--- a/php/7.0/Dockerfile
+++ b/php/7.0/Dockerfile
@@ -1,25 +1,28 @@
 FROM php:7.0-fpm
 
-ENV Dependencies "ssmtp libfreetype6 libjpeg62-turbo unzip git mysql-client sudo rsync liblz4-tool"
-ENV TempDependencies "libcurl4-openssl-dev libjpeg-dev libpng-dev libxml2-dev"
+ARG RUNTIME_PACKAGE_DEPS="ssmtp libfreetype6 libjpeg62-turbo unzip git mysql-client sudo rsync liblz4-tool"
+ARG BUILD_PACKAGE_DEPS="libcurl4-openssl-dev libjpeg-dev libpng-dev libxml2-dev"
+ARG PHP_EXT_DEPS="curl json xml mbstring zip bcmath soap pdo_mysql gd mysqli"
+ARG PHP_MEMORY_LIMIT="-1"
 
 # install dependencies and cleanup (needs to be one step, as else it will cache in the laver)
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-    $Dependencies $TempDependencies && \
-    docker-php-ext-configure gd --with-jpeg-dir=/usr/local/ && \
-    docker-php-ext-install -j$(nproc) curl json xml mbstring zip bcmath soap pdo_mysql gd mysqli && \
-    pecl install xdebug && \
-    apt-get clean && \
-    apt-get autoremove -y && \
-    apt-get purge -y --auto-remove $TempDependencies && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        $RUNTIME_PACKAGE_DEPS \
+        $BUILD_PACKAGE_DEPS \
+    && docker-php-ext-configure gd --with-jpeg-dir=/usr/local/ \
+    && docker-php-ext-install -j$(nproc) $PHP_EXT_DEPS \
+    && pecl install xdebug \
+    && apt-get clean \
+    && apt-get autoremove -y \
+    && apt-get purge -y --auto-remove $BUILD_PACKAGE_DEPS \
+    && rm -rf /var/lib/apt/lists/*
 
 # set sendmail for php to ssmtp
 RUN echo "sendmail_path=/usr/sbin/ssmtp -t" > /usr/local/etc/php/conf.d/php-sendmail.ini
 
 # remove memory limit
-RUN echo "memory_limit = -1" > /usr/local/etc/php/conf.d/memory-limit-php.ini
+RUN echo "memory_limit = $PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit-php.ini
 
 # prepare optional xdebug ini
 RUN echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/optional_xdebug.ini && \

--- a/php/7.1/Dockerfile
+++ b/php/7.1/Dockerfile
@@ -1,27 +1,31 @@
-FROM php:7.1-fpm
+ARG PHP_VERSION=7.1
+FROM php:$PHP_VERSION-fpm
 
-ENV Dependencies "ssmtp libfreetype6 libjpeg62-turbo unzip git mysql-client sudo rsync liblz4-tool"
-ENV TempDependencies "libcurl4-openssl-dev libjpeg-dev libpng-dev libxml2-dev"
+ARG RUNTIME_PACKAGE_DEPS="ssmtp libfreetype6 libjpeg62-turbo unzip git mysql-client sudo rsync liblz4-tool"
+ARG BUILD_PACKAGE_DEPS="libcurl4-openssl-dev libjpeg-dev libpng-dev libxml2-dev"
+ARG PHP_EXT_DEPS="curl json xml mbstring zip bcmath soap pdo_mysql gd mysqli"
+ARG PHP_MEMORY_LIMIT="-1"
 
 # install dependencies and cleanup (needs to be one step, as else it will cache in the laver)
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-    $Dependencies $TempDependencies && \
-    docker-php-ext-configure gd --with-jpeg-dir=/usr/local/ && \
-    docker-php-ext-install -j$(nproc) curl json xml mbstring zip bcmath soap pdo_mysql gd mysqli && \
-    pecl install xdebug && \
-    apt-get clean && \
-    apt-get autoremove -y && \
-    apt-get purge -y --auto-remove $TempDependencies && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        $RUNTIME_PACKAGE_DEPS \
+        $BUILD_PACKAGE_DEPS \
+    && docker-php-ext-configure gd --with-jpeg-dir=/usr/local/ \
+    && docker-php-ext-install -j$(nproc) $PHP_EXT_DEPS \
+    && pecl install xdebug \
+    && apt-get clean \
+    && apt-get autoremove -y \
+    && apt-get purge -y --auto-remove $BUILD_PACKAGE_DEPS \
+    && rm -rf /var/lib/apt/lists/*
 
 # set sendmail for php to ssmtp
 RUN echo "sendmail_path=/usr/sbin/ssmtp -t" > /usr/local/etc/php/conf.d/php-sendmail.ini
 
 # remove memory limit
-RUN echo "memory_limit = -1" > /usr/local/etc/php/conf.d/memory-limit-php.ini
+RUN echo "memory_limit = $PHP_MEMORY_LIMIT" > /usr/local/etc/php/conf.d/memory-limit-php.ini
 
-# prepare optional xdebug.ini
+# prepare optional xdebug ini
 RUN echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/optional_xdebug.ini && \
     echo "xdebug.remote_enable=on" >> /usr/optional_xdebug.ini && \
     echo "xdebug.remote_autostart=off" >> /usr/optional_xdebug.ini


### PR DESCRIPTION
The Dockerfile is parametrized the Docker way by using ARG. This way the runtime env in the container won't be polluted by unneccessary stuff.
Now it is possible to setup different PHP base container builds just from one Dockerfile (for this just one Dockerfile is needed) and the version to be built should be passed as an argument in the Docker Hub automated build setup.  The tag will correspond to the argument passed.