### PR TITLE
Update packages in order to run on the new stable debian version

### DIFF
--- a/php/7.0/Dockerfile
+++ b/php/7.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.0-fpm
 
-ENV Dependencies "ssmtp libfreetype6 libjpeg62-turbo unzip git mysql-client sudo rsync liblz4-tool"
+ENV Dependencies "msmtp libfreetype6 libjpeg62-turbo unzip git default-mysql-client sudo rsync liblz4-tool"
 ENV TempDependencies "libcurl4-openssl-dev libjpeg-dev libpng-dev libxml2-dev"
 
 # install dependencies and cleanup (needs to be one step, as else it will cache in the laver)
@@ -15,8 +15,8 @@ RUN apt-get update -y && \
     apt-get purge -y --auto-remove $TempDependencies && \
     rm -rf /var/lib/apt/lists/*
 
-# set sendmail for php to ssmtp
-RUN echo "sendmail_path=/usr/sbin/ssmtp -t" > /usr/local/etc/php/conf.d/php-sendmail.ini
+# set sendmail for php to msmtp
+RUN echo "sendmail_path=/usr/sbin/msmtp -t" > /usr/local/etc/php/conf.d/php-sendmail.ini
 
 # remove memory limit
 RUN echo "memory_limit = -1" > /usr/local/etc/php/conf.d/memory-limit-php.ini

--- a/php/7.1/Dockerfile
+++ b/php/7.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.1-fpm
 
-ENV Dependencies "ssmtp libfreetype6 libjpeg62-turbo unzip git mysql-client sudo rsync liblz4-tool"
+ENV Dependencies "msmtp libfreetype6 libjpeg62-turbo unzip git default-mysql-client sudo rsync liblz4-tool"
 ENV TempDependencies "libcurl4-openssl-dev libjpeg-dev libpng-dev libxml2-dev"
 
 # install dependencies and cleanup (needs to be one step, as else it will cache in the laver)
@@ -15,8 +15,8 @@ RUN apt-get update -y && \
     apt-get purge -y --auto-remove $TempDependencies && \
     rm -rf /var/lib/apt/lists/*
 
-# set sendmail for php to ssmtp
-RUN echo "sendmail_path=/usr/sbin/ssmtp -t" > /usr/local/etc/php/conf.d/php-sendmail.ini
+# set sendmail for php to msmtp
+RUN echo "sendmail_path=/usr/sbin/msmtp -t" > /usr/local/etc/php/conf.d/php-sendmail.ini
 
 # remove memory limit
 RUN echo "memory_limit = -1" > /usr/local/etc/php/conf.d/memory-limit-php.ini

--- a/php/README.md
+++ b/php/README.md
@@ -1,11 +1,11 @@
-Extended PHP base container 
+Extended PHP base container
 ===========================
 
 Based on the images provided at https://hub.docker.com/_/php.
 
 Changes contain:
 - Installing necessary PHP-extensions
-- Use of ssmtp for sendmail
+- Use of msmtp for sendmail
 - Removing memory limits on PHP
 - Installing Xdebug and provide an option to enable it
 - Installing Composer


### PR DESCRIPTION
Buster is the new stable debian version. ssmtp package is no longer
available and was replaced by msmtp. The same for client-mysql replaced by
default-mysql-client, which install mariadb-client-10.3 as dependency.