### PR TITLE
Add quotation marks to PHP version numbers

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: [7.4, 8.0, 8.1, 8.2]
+        php_version: ["7.4", "8.0", "8.1", "8.2"]
         include:
           - php_version: 7.4
             RUNTIME_PACKAGE_DEPS: "msmtp libfreetype6 libjpeg62-turbo unzip git default-mysql-client sudo rsync liblz4-tool libzip-dev bc iproute2 libmemcached-dev libonig-dev openssh-client sshpass"
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2      
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Log into Docker Hub


### PR DESCRIPTION
Add quotation marks so that the PHP version number 8.0 is not misinterpreted as 8.

Currently the PHP image for version `8.0` is pushed as `8`. See https://hub.docker.com/r/oxidesales/oxideshop-docker-php/tags