### PR TITLE
Add php8.3 docker images

### DIFF
--- a/.github/workflows/build-php-images.yml
+++ b/.github/workflows/build-php-images.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["7.4", "8.0", "8.1", "8.2"]
+        php_version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
         include:
           - php_version: 7.4
             RUNTIME_PACKAGE_DEPS: "msmtp libfreetype6 libjpeg62-turbo unzip git default-mysql-client sudo rsync liblz4-tool libzip-dev bc iproute2 libmemcached-dev libonig-dev openssh-client sshpass libgd3"
@@ -46,7 +46,13 @@ jobs:
             GD_CONFIG: "--with-jpeg=/usr/local/ --with-webp=/usr/local/"
             PECL_DEPS: "pecl install xdebug memcached"
             XDEBUG_INI: "xdebug3.ini"
-            
+          - php_version: 8.3
+            RUNTIME_PACKAGE_DEPS: "msmtp libfreetype6 libjpeg62-turbo libwebp-dev unzip git default-mysql-client sudo rsync liblz4-tool libzip-dev bc iproute2 libmemcached-dev libonig-dev openssh-client sshpass libssl-dev libgd3"
+            BUILD_PACKAGE_DEPS: "libcurl4-openssl-dev libjpeg-dev libpng-dev libxml2-dev"
+            PHP_EXT_DEPS: "zip bcmath soap pdo_mysql gd mysqli"
+            GD_CONFIG: "--with-jpeg=/usr/local/ --with-webp=/usr/local/"
+            PECL_DEPS: "pecl install xdebug memcached"
+            XDEBUG_INI: "xdebug3.ini"
     steps:
       - name: build and push docker images
         uses: 'OXID-eSales/github-actions/build_docker@v3'

--- a/php/build.sh
+++ b/php/build.sh
@@ -112,6 +112,22 @@ if [[ $1 == "8.2" ]]; then
   exit 0
 fi
 
+if [[ $1 == "8.3" ]]; then
+  DOCKER_BUILD_ARGUMENTS=()
+  DOCKER_BUILD_ARGUMENTS+=('--build-arg PHP_VERSION=8.3')
+  DOCKER_BUILD_ARGUMENTS+=("--build-arg RUNTIME_PACKAGE_DEPS='msmtp libfreetype6 libjpeg62-turbo libwebp-dev unzip git default-mysql-client sudo rsync liblz4-tool libzip-dev bc iproute2 libmemcached-dev libonig-dev openssh-client sshpass libssl-dev libgd3'")
+  DOCKER_BUILD_ARGUMENTS+=("--build-arg BUILD_PACKAGE_DEPS='libcurl4-openssl-dev libjpeg-dev libpng-dev libxml2-dev'")
+  DOCKER_BUILD_ARGUMENTS+=("--build-arg PHP_EXT_DEPS='zip bcmath soap pdo_mysql gd mysqli'")
+  DOCKER_BUILD_ARGUMENTS+=("--build-arg GD_CONFIG='--with-jpeg=/usr/local/ --with-webp=/usr/local/'")
+  DOCKER_BUILD_ARGUMENTS+=("--build-arg PECL_DEPS='pecl install xdebug memcached'")
+  DOCKER_BUILD_ARGUMENTS+=("--build-arg XDEBUG_INI='xdebug3.ini'")
+  BUILD="docker build --no-cache ${DOCKER_BUILD_ARGUMENTS[*]} -t oxidesales/oxideshop-docker-php:8.3 ."
+  echo $BUILD
+  eval $BUILD
+  exit 0
+fi
+
+
 if [[ $1 == [0-9]\.[0-9] ]]; then
   echo "Version $1 is not supported."
   exit 128


### PR DESCRIPTION
Making PHP 8.3 docker images available, copying the 8.2 settings. The build has been successful: https://github.com/OXID-eSales/docker/actions/runs/7870018135/job/21470370614