### PR TITLE
Pin composer 2 version to 2.2

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -46,8 +46,8 @@ RUN ln -s /usr/local/bin/php /usr/bin/php
 # install latest composer v1 as composer1 binary
 COPY --from=composer:1 /usr/bin/composer /usr/bin/composer1
 
-# install latest composer v2 as composer2 binary
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+# install composer v2.2 as composer2 binary (latest or 2 drops php 7.1)
+COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer
 
 # Workaround for https://oxid-esales.atlassian.net/browse/OXDEV-4797
 RUN echo "php_admin_value[error_log] = /tmp/fpm-php.www.log" >> /usr/local/etc/php-fpm.d/www.conf


### PR DESCRIPTION
According to https://github.com/OXID-eSales/docker-eshop-sdk/issues/27, the latest v2 of composer drops support for PHP 7.1, so we need to pin this to version 2.2 of composer